### PR TITLE
Replace macros and read conditionals with compile

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -2,7 +2,8 @@
 
 (defpackage #:livesupport
   (:use #:cl)
-  (:export :update-repl-link
+  (:export :reset-livecoding
+           :update-repl-link
            :peek
            :continuable
            :find-initial-thread

--- a/package.lisp
+++ b/package.lisp
@@ -3,6 +3,7 @@
 (defpackage #:livesupport
   (:use #:cl)
   (:export :reset-livecoding
+           :setup-lisp-repl
            :update-repl-link
            :peek
            :continuable


### PR DESCRIPTION
This allows the livesupport backend (slynk, swank, or nil) to be selected at load time and even switched out at runtime.

This has not been extensively tested, although I used a previous version of this code for a few hours earlier today. It also loads on a fresh image without errors and was mostly just a mechanical rewrite from the macrolet version, so I doubt there are any serious new bugs hiding in there.

The changes introduce two new functions. One, reset-livecoding, actually handles swapping out all of the functions as needed. The other is setup-repl-link, which is needed for proper slynk support. This function needs to be called when the nested repl context is started, as calling HANDLE-REQUESTS is not enough for sly to drop its "repl is busy" message and allow typing in the repl again.