### PR TITLE
Fix error when enabling livesupport without mrepl

### DIFF
--- a/livesupport.lisp
+++ b/livesupport.lisp
@@ -35,11 +35,13 @@
               (case repl-backend
                 (:slynk
                  `(lambda ()
-                    (let ((repl (find (,(intern "CURRENT-THREAD" repl-backend))
-                                      (,(intern "CHANNELS" repl-backend))
-                                      :key #',(intern "CHANNEL-THREAD" repl-backend))))
-                      (when repl
-                        (,(intern "SEND-PROMPT" "SLYNK-MREPL") repl)))))
+                    ,(if (find-package "SLYNK-MREPL")
+                         `(let ((repl (find (,(intern "CURRENT-THREAD" repl-backend))
+                                            (,(intern "CHANNELS" repl-backend))
+                                            :key #',(intern "CHANNEL-THREAD" repl-backend))))
+                            (when repl
+                              (,(intern "SEND-PROMPT" "SLYNK-MREPL") repl)))
+                         `(values))))
                 (otherwise (lambda () (values)))))
 
      (compile 'update-repl-link


### PR DESCRIPTION
It's possible to have Slynk loaded without the slynk-mrepl contrib. When calling `reset-livecoding`, intern gets called on `slynk-mrepl` package if the `slynk` package is available, causing an error in trying to find the package.

This change makes `setup-lisp-repl` into a no-op when `slynk-mrepl` isn't present during the call to `reset-livecoding`